### PR TITLE
pathの修正

### DIFF
--- a/theaterface/index.php
+++ b/theaterface/index.php
@@ -9,7 +9,7 @@
 			
 			
 				<div class="formArea">
-	        <form method="post" action="/<?php echo $_POST['tsInput'] ?>">
+	        <form method="post" action="<?php echo $_POST['tsInput'] ?>">
 	        	<dl class="searchBox">
 							<dt><input type="text" class="tsInput" name="tsInput" value="<?php echo $_POST['tsInput'] ?>"></dt>
 							<dd><button type="submit" name="" value=""><span></span></button></dd>


### PR DESCRIPTION
@shohei000 ページ制作おつかれさまです！

index.phpを拝見させていただきましたが、
formタグのactionが `/<?php echo $_POST['tsInput'] ?>`となっていたものを
`<?php echo $_POST['tsInput'] ?>`に変更しました。
`/`が入ることにより、検索時に移動する場所が大きく変わってしまうためです。

以下のgifは自分のローカル環境で試したものですが、**一応**移動できるようにはなっています。
(一応と書いたのは、なぜか2回検索ボタンを押さないとページ遷移しないためです)

![gif](http://g.recordit.co/Ia6dfnffdj.gif)

これだけで上手くいかない場合は、お使いのレンタルサーバー内の設定を弄る必要があるかもしれません。一旦こちらの修正で試していただけますか？
